### PR TITLE
use subactivity to find diagrams when possible

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,11 @@ define(function (require, exports, module) {
 
         var element = SelectionManager.getSelected();
         
+        // use subactivity when no ownedElements are present and subactivity is set
+        if (element.ownedElements.length < 1 && element.subactivity) {
+            element = element.subactivity;
+        }
+        
         if (element) {
             var foundDiagrams = [];
 


### PR DESCRIPTION
What I just did was:
1. I created an Activity with underlying Activity diagram
2. drag-dropped the Activity on another Activity diagram

A new Action gets created in the diagram which has "subactivity" set to the Activity I dropped.
That Action has no name initially and can be found in the Model Explorer as "(Action)" after creation.

Now my change will check the subactivity property (but only if the Action itself has no ownedElements).
This could maybe optimized later to always check all ownedElements under the selected element as well as the subactivity if present).