### PR TITLE
Added diving into subactivity for activity diagram

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,8 +24,12 @@ function _handleOpenLinkedDiagram()
     if (element)
     {
         var foundDiagrams = [];
+        
+        var oe = element.ownedElements;
+        if(element.subactivity && element.ownedElements.lenght == 0 && element.subactivity.ownedElements.length > 0)
+            oe = element.subactivity.ownedElements;
 
-        element.ownedElements.forEach(function(ele)
+        oe.forEach(function(ele)
         {
             if (ele instanceof type.UMLDiagram ||
                 ele instanceof type.ERDDiagram ||


### PR DESCRIPTION
Hello Marco,

I added a missing feature to be able to dive into subactivities of an activity diagram.
Doing so, you can compose activity diagrams by reusing smaller, previously defined activities.

Best regards,

Edoardo.