### PR TITLE
added the feature that it open parent diagram of current diagram.

### DIFF
--- a/keymaps/LinkedDiagramNavigator_keymap.json
+++ b/keymaps/LinkedDiagramNavigator_keymap.json
@@ -1,3 +1,4 @@
 {
-    "cmdctrl-l": "linked_diagram_navigator:open_linked_diagram"
+    "cmdctrl-l": "linked_diagram_navigator:open_child_diagram",
+    "cmdctrl-k": "linked_diagram_navigator:open_parent_diagram"
 }

--- a/menus/LinkedDiagramNavigator_menu.json
+++ b/menus/LinkedDiagramNavigator_menu.json
@@ -3,9 +3,14 @@
         "#diagram-canvas": [
             { "type": "separator" },
             {
-                "label": "Open linked diagram",
-                "id": "linked_diagram_navigator_ctx_menu",
-                "command": "linked_diagram_navigator:open_linked_diagram"
+                "label": "Open child diagram",
+                "id": "linked_diagram_navigator_ctx_menu_for_child",
+                "command": "linked_diagram_navigator:open_child_diagram"
+            },
+            {
+                "label": "Open parent diagram",
+                "id": "linked_diagram_navigator_ctx_menu_for_parent",
+                "command": "linked_diagram_navigator:open_parent_diagram"
             }
         ]
     }


### PR DESCRIPTION
I enabled to open a parent diagram of the current diagram like a child diagram is open. 
(but then no element need to be selected)

I needed to change the expression "linked" in the context menu to implement this. 
thus "linked diagram" changed to "child diagram".

although it may be off a bit from purpose for this repo, use it if you like.